### PR TITLE
fix: address critical PR 9 feedback issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,7 +582,6 @@ wt env-copy feature    # Shows: "Consider using 'wt env sync' instead"
 - Add new subcommands alongside existing commands
 - Extend existing commands with new flags
 - Provide multiple interfaces to the same functionality
-- Use deprecation warnings before removal
 
 ## Claude Code Integration
 

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -426,9 +426,6 @@ func handleEnvCopyCommand(args []string) {
 		return
 	}
 
-	// Show deprecation warning
-	fmt.Println("Warning: 'wt env-copy' is deprecated. Use 'wt env sync' instead.")
-
 	// Parse flags
 	var useFuzzy bool
 	var target string

--- a/cmd/wt/main_test.go
+++ b/cmd/wt/main_test.go
@@ -43,25 +43,25 @@ func TestHandleVersionCommand(t *testing.T) {
 	tests := []struct {
 		name        string
 		version     string
-		buildTime   string
+		date        string
 		wantContain string
 	}{
 		{
 			name:        "with version and build time",
 			version:     "1.2.3",
-			buildTime:   "2024-01-01",
+			date:        "2024-01-01",
 			wantContain: "wt version 1.2.3 (built 2024-01-01)",
 		},
 		{
 			name:        "development version",
 			version:     "dev",
-			buildTime:   "",
+			date:        "",
 			wantContain: "wt version dev",
 		},
 		{
 			name:        "empty version",
 			version:     "",
-			buildTime:   "",
+			date:        "",
 			wantContain: "wt version dev",
 		},
 	}
@@ -69,7 +69,7 @@ func TestHandleVersionCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			version = tt.version
-			buildTime = tt.buildTime
+			date = tt.date
 
 			stdout, _, err := captureOutput(func() error {
 				handleVersionCommand([]string{})


### PR DESCRIPTION
- Fix build-time variable mismatch: rename buildTime to date to match Makefile
- Remove deprecation warning for env-copy command (personal tool, no deprecation needed)
- Standardize error handling by using printErrorAndExit consistently
- Add documentation for future error handling improvements
- Add security improvements: path validation for virtualenv operations
- Add proper shell quoting for paths to prevent injection

These changes address the most critical issues from PR 9 review while maintaining backward compatibility. Future PRs will tackle larger refactoring items like shell wrapper extraction and comprehensive error handling patterns.