### PR TITLE
feat: multi-line display format for wt recent

### DIFF
--- a/backlog/tasks/task-24 - Optimize-worktree-info-caching-in-wt-recent.md
+++ b/backlog/tasks/task-24 - Optimize-worktree-info-caching-in-wt-recent.md
@@ -1,7 +1,8 @@
 ---
 id: task-24
 title: Optimize worktree info caching in wt recent
-status: To Do
+status: Won't Do
+updated_date: '2025-07-11'
 assignee: []
 created_date: '2025-07-11'
 labels: []
@@ -19,3 +20,19 @@ The updateWorktreeInfo function in wt recent could be expensive with many worktr
 - [ ] Only update worktree info when displaying branches with worktrees
 - [ ] Measure performance improvement with many worktrees
 - [ ] Ensure cache invalidation when worktrees change
+
+## Implementation Notes
+
+**Decision: Won't implement**
+
+Based on performance benchmarks from task-22, caching is not needed:
+
+- Branch filtering performance is excellent (< 0.2ms for 10,000 branches)
+- The bottleneck is git operations (`git for-each-ref`, `git worktree list`), not our Go code
+- Caching worktree info in memory wouldn't help since:
+  - We still need to call git commands each time
+  - The Go processing is already extremely fast
+  - Most users won't have hundreds of worktrees (typical usage is < 10)
+- Adding caching would increase complexity without meaningful performance gains
+
+The real bottleneck is git command execution time, which caching cannot improve.

--- a/backlog/tasks/task-25 - Improve-multi-line-format-alignment-in-wt-recent.md
+++ b/backlog/tasks/task-25 - Improve-multi-line-format-alignment-in-wt-recent.md
@@ -1,0 +1,42 @@
+---
+id: task-25
+title: Improve multi-line format alignment in wt recent
+status: Done
+assignee: []
+created_date: '2025-07-11'
+updated_date: '2025-07-11'
+labels:
+  - high-priority
+  - formatting
+dependencies: []
+---
+
+## Description
+
+Fix alignment issues in the multi-line display format. The star should be directly attached to the branch name, and subsequent lines should align with the branch name, not the index. Add blank lines between entries for better readability.
+
+## Acceptance Criteria
+
+- [x] Star directly next to branch name (0: *branch)
+- [x] Second/third lines align with branch name
+- [x] Blank line between entries
+- [x] No truncation in multi-line mode
+
+## Implementation Plan
+
+1. Modify displayBranches function to show star directly after colon
+2. Ensure proper indentation for second and third lines
+3. Add blank lines between all entries (except after last)
+4. Update tests to match new format
+
+## Implementation Notes
+
+Successfully improved the multi-line format alignment:
+
+- Star is now directly attached to branch name: `0: *branch-name`
+- Second and third lines are indented with 3 spaces to align with branch name
+- Blank lines added between all entries for better readability
+- No truncation in multi-line mode (full branch names shown)
+- Tests updated to verify the new format
+
+The format is now much cleaner and easier to scan, especially with long branch names.

--- a/backlog/tasks/task-26 - Add-configuration-management-commands-to-wt.md
+++ b/backlog/tasks/task-26 - Add-configuration-management-commands-to-wt.md
@@ -1,0 +1,26 @@
+---
+id: task-26
+title: Add configuration management commands to wt
+status: To Do
+assignee: []
+created_date: '2025-07-11'
+updated_date: '2025-07-11'
+labels:
+  - high-priority
+  - config
+dependencies: []
+---
+
+## Description
+
+Implement a set of commands to manage wt configuration without manually editing config files. This improves usability by providing quick access to configuration values and the ability to edit them from the command line.
+
+## Acceptance Criteria
+
+- [ ] wt config list - show all config values
+- [ ] wt config get <key> - get specific value
+- [ ] wt config set <key> <value> - set value
+- [ ] wt config edit - open in editor
+- [ ] wt config path - show file path
+- [ ] wt config dir - navigate to config dir
+- [ ] Editor selection (wt.editor then  then )

--- a/backlog/tasks/task-27 - Improve-compact-mode-wrapping-and-truncation-behavior.md
+++ b/backlog/tasks/task-27 - Improve-compact-mode-wrapping-and-truncation-behavior.md
@@ -1,0 +1,23 @@
+---
+id: task-27
+title: Improve compact mode wrapping and truncation behavior
+status: To Do
+assignee: []
+created_date: '2025-07-11'
+updated_date: '2025-07-11'
+labels:
+  - low-priority
+  - formatting
+dependencies: []
+---
+
+## Description
+
+The current truncation in compact mode doesn't make sense when terminals already wrap text naturally. Improve the behavior to either wrap properly or make truncation configurable, especially for narrow terminal windows.
+
+## Acceptance Criteria
+
+- [ ] Remove or make truncation optional in compact mode
+- [ ] Consider terminal width for smart wrapping
+- [ ] Add --no-truncate flag for scripts
+- [ ] Make truncation width configurable

--- a/backlog/tasks/task-28 - Add-terminal-width-detection-for-smart-formatting.md
+++ b/backlog/tasks/task-28 - Add-terminal-width-detection-for-smart-formatting.md
@@ -1,0 +1,23 @@
+---
+id: task-28
+title: Add terminal width detection for smart formatting
+status: To Do
+assignee: []
+created_date: '2025-07-11'
+updated_date: '2025-07-11'
+labels:
+  - low-priority
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+Detect terminal width to make intelligent decisions about when to truncate or wrap text. This would improve the display on various terminal sizes without manual configuration.
+
+## Acceptance Criteria
+
+- [ ] Detect terminal width using appropriate system calls
+- [ ] Use width to determine truncation behavior
+- [ ] Graceful fallback when width cannot be detected
+- [ ] Work correctly with terminal resizing

--- a/backlog/tasks/task-29 - Implement-worktree-setup-automation.md
+++ b/backlog/tasks/task-29 - Implement-worktree-setup-automation.md
@@ -1,0 +1,24 @@
+---
+id: task-29
+title: Implement worktree setup automation
+status: To Do
+assignee: []
+created_date: '2025-07-11'
+updated_date: '2025-07-11'
+labels:
+  - future
+  - automation
+dependencies: []
+---
+
+## Description
+
+Add the ability to define and run automatic setup steps when creating new worktrees. This could include running npm install, syncing env files, and other project-specific initialization tasks.
+
+## Acceptance Criteria
+
+- [ ] Define setup steps in project config
+- [ ] Run setup automatically on wt new
+- [ ] Support various command types
+- [ ] Handle setup failures gracefully
+- [ ] Optional manual trigger with wt setup

--- a/backlog/tasks/task-30 - Add-port-management-for-parallel-worktree-development.md
+++ b/backlog/tasks/task-30 - Add-port-management-for-parallel-worktree-development.md
@@ -1,0 +1,24 @@
+---
+id: task-30
+title: Add port management for parallel worktree development
+status: To Do
+assignee: []
+created_date: '2025-07-11'
+updated_date: '2025-07-11'
+labels:
+  - future
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+When working with multiple worktrees in parallel, port conflicts are common. Implement a system to track and allocate unique ports for each worktree to enable true parallel development.
+
+## Acceptance Criteria
+
+- [ ] Track ports in use per worktree
+- [ ] Allocate unique ports on setup
+- [ ] Configure services with allocated ports
+- [ ] Show port allocation with wt ports
+- [ ] Free ports when worktree removed

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -1625,21 +1625,21 @@ func displayBranches(branches []branchCommitInfo, count int) {
 
 	for i := 0; i < displayCount; i++ {
 		branch := branches[i]
-		worktreeIndicator := " "
+
+		// First line: index with proper spacing, then branch name with star
 		if branch.hasWorktree {
-			worktreeIndicator = "*"
+			fmt.Printf("%d: *%s\n", i, branch.branch)
+		} else {
+			fmt.Printf("%d: %s\n", i, branch.branch)
 		}
 
-		// First line: index, worktree indicator, and full branch name
-		fmt.Printf("%d:%s %s\n", i, worktreeIndicator, branch.branch)
-
-		// Second line: commit subject (indented)
+		// Second line: commit subject (indented to align with branch name)
 		fmt.Printf("   %s\n", branch.subject)
 
-		// Third line: author and date (indented)
+		// Third line: author and date (indented to align with branch name)
 		fmt.Printf("   %s, %s\n", branch.author, branch.relativeDate)
 
-		// Add blank line between entries for readability
+		// Add blank line between entries (but not after the last one)
 		if i < displayCount-1 {
 			fmt.Println()
 		}

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -76,8 +76,8 @@ wt() {
       elif [[ "$line" == "EXEC:"* ]]; then
         exec_cmd="${line#EXEC:}"
       else
-        # Print non-command lines
-        [ -n "$line" ] && echo "$line"
+        # Print non-command lines (including empty lines)
+        echo "$line"
       fi
     done <<< "$output"
 

--- a/cmd/wt/main.go
+++ b/cmd/wt/main.go
@@ -288,7 +288,11 @@ func handleRecentCommand(args []string) {
 	}
 
 	// Display branches
-	displayBranches(branches, flags.count)
+	if flags.compact {
+		displayBranchesCompact(branches, flags.count)
+	} else {
+		displayBranches(branches, flags.count)
+	}
 
 	// Display summary of skipped branches if verbose mode is enabled
 	displaySkippedBranchesIfVerbose(branchResult.skipped, flags.verbose)
@@ -1138,7 +1142,8 @@ Smart commands (with fuzzy branch matching):
   list, ls            List all worktrees
   recent              Show YOUR recently active branches (default: your branches only)
                       Navigate directly: 'wt recent 2' → go to your 3rd recent branch
-                      Options: --all, --others, -n <count>
+                      Default: multi-line format for better readability
+                      Options: --all, --others, -n <count>, --compact, --verbose
   new <branch>        Smart worktree creation - handles all branch states:
                       • Branch doesn't exist → Create branch + worktree + switch
                       • Branch exists, no worktree → Create worktree + switch
@@ -1351,6 +1356,7 @@ type recentFlags struct {
 	count         int
 	navigateIndex int
 	verbose       bool
+	compact       bool
 }
 
 // parseRecentFlags parses command line flags for the recent command
@@ -1372,6 +1378,9 @@ func parseRecentFlags(args []string) recentFlags {
 			i++
 		case arg == "--verbose" || arg == "-v":
 			flags.verbose = true
+			i++
+		case arg == "--compact" || arg == "-c":
+			flags.compact = true
 			i++
 		case arg == "-n" && i+1 < len(args):
 			flags.count = parseAndValidateCount(args[i+1])
@@ -1603,8 +1612,42 @@ func navigateToBranch(branches []branchCommitInfo, index int, gitClient git.Clie
 	}
 }
 
-// displayBranches shows the list of branches with formatting
+// displayBranches shows the list of branches in multi-line format (default)
 func displayBranches(branches []branchCommitInfo, count int) {
+	displayCount := len(branches)
+	if displayCount > count {
+		displayCount = count
+	}
+
+	if displayCount == 0 {
+		return
+	}
+
+	for i := 0; i < displayCount; i++ {
+		branch := branches[i]
+		worktreeIndicator := " "
+		if branch.hasWorktree {
+			worktreeIndicator = "*"
+		}
+
+		// First line: index, worktree indicator, and full branch name
+		fmt.Printf("%d:%s %s\n", i, worktreeIndicator, branch.branch)
+
+		// Second line: commit subject (indented)
+		fmt.Printf("   %s\n", branch.subject)
+
+		// Third line: author and date (indented)
+		fmt.Printf("   %s, %s\n", branch.author, branch.relativeDate)
+
+		// Add blank line between entries for readability
+		if i < displayCount-1 {
+			fmt.Println()
+		}
+	}
+}
+
+// displayBranchesCompact shows the list of branches in compact single-line format
+func displayBranchesCompact(branches []branchCommitInfo, count int) {
 	displayCount := len(branches)
 	if displayCount > count {
 		displayCount = count

--- a/cmd/wt/recent_test.go
+++ b/cmd/wt/recent_test.go
@@ -846,7 +846,7 @@ func TestDisplayBranchesMultiline(t *testing.T) {
 		}
 
 		// Check first branch format
-		if !strings.HasPrefix(lines[0], "0:* feature/very-long-branch-name-with-issue-123") {
+		if !strings.HasPrefix(lines[0], "0: *feature/very-long-branch-name-with-issue-123") {
 			t.Errorf("First line doesn't match expected format: %s", lines[0])
 		}
 
@@ -858,9 +858,34 @@ func TestDisplayBranchesMultiline(t *testing.T) {
 			t.Error("Third line should be indented")
 		}
 
-		// Check that there's a blank line
+		// Check that there's a blank line after first entry
 		if lines[3] != "" {
-			t.Error("Expected blank line between entries")
+			t.Error("Expected blank line after first entry")
+		}
+
+		// Check second branch doesn't have star (no worktree)
+		if !strings.HasPrefix(lines[4], "1: fix/issue-456") {
+			t.Errorf("Fifth line doesn't match expected format: %s", lines[4])
+		}
+	})
+
+	t.Run("empty branch list", func(t *testing.T) {
+		var branches []branchCommitInfo
+
+		// Capture output
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		displayBranches(branches, 10)
+
+		w.Close()
+		output, _ := io.ReadAll(r)
+		os.Stdout = oldStdout
+
+		// Should produce no output
+		if len(output) != 0 {
+			t.Errorf("Expected no output for empty branch list, got: %s", string(output))
 		}
 	})
 }

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -375,7 +375,7 @@ var commandHelpMap = map[string]CommandHelp{
 	"recent": {
 		Name:        "recent",
 		Usage:       "wt recent [index] [options]",
-		Description: "Show and navigate to your recently active branches (default: only your branches)",
+		Description: "Show and navigate to your recently active branches (default: only your branches, multi-line format)",
 		Examples: []string{
 			"wt recent                    # List your 10 most recent branches",
 			"wt recent -n 20              # List your 20 most recent branches",
@@ -405,6 +405,12 @@ var commandHelpMap = map[string]CommandHelp{
 				ShortFlag:   "-v",
 				Description: "Show detailed information about skipped branches",
 				Example:     "wt recent --verbose",
+			},
+			{
+				Flag:        "--compact",
+				ShortFlag:   "-c",
+				Description: "Use compact single-line format instead of multi-line",
+				Example:     "wt recent --compact",
 			},
 		},
 		SeeAlso: []string{"wt list", "wt go", "wt new"},


### PR DESCRIPTION
## Summary

This PR changes the default display format for `wt recent` to a multi-line format that shows full branch names without truncation, which is much better for small terminal windows.

## Changes

- **Multi-line format is now the default** - Each branch entry displays across 3 lines:
  - Line 1: Index, worktree indicator (*), and full branch name
  - Line 2: Commit subject (indented)
  - Line 3: Author and date (indented)
  - Blank line between entries for readability

- **Added `--compact`/`-c` flag** - Use this to get the previous single-line format

- **No more truncation** - Branch names are shown in full, solving the issue with long branch names

- **Updated help documentation** - Reflects the new default behavior

## Why this change?

As mentioned in the discussion, when working with small terminal displays (like tmux panes), the truncated branch names were problematic. With naming schemes like `<username>/<issue-id>/<description>`, branch names get very long and important information was being cut off.

The multi-line format solves this by:
- Showing the full branch name
- Better visual separation between branches
- More readable layout for scanning through branches

## Example Output

### Default (multi-line):
```
0:* feat/multiline-recent-display
   feat: add performance benchmarks for wt recent command
   Tobias Englert, 2 hours ago

1:  fix/recent-error-handling-and-tests
   feat: add performance benchmarks for wt recent command
   Tobias Englert, 2 hours ago
```

### With --compact flag:
```
0: *feat/multiline-recent-display       2 hours ago feat: add performance benchmarks for wt recent ... Tobias Englert
1:  fix/recent-error-handling-and-tests 2 hours ago feat: add performance benchmarks for wt recent ... Tobias Englert
```

## Also included

- Closed task-24 (worktree caching) as won't implement, based on benchmark results showing the bottleneck is git operations, not our Go code

## Test Plan

- [x] Unit tests added for both display formats
- [x] Manual testing with various branch name lengths
- [x] Verified help documentation is accurate
- [x] All existing tests pass